### PR TITLE
ADCS review

### DIFF
--- a/software/FossaSat2/src/ADCS/ACS/acs.h
+++ b/software/FossaSat2/src/ADCS/ACS/acs.h
@@ -14,7 +14,7 @@ void ACS_BdotFunction(const ADCS_CALC_TYPE omega[ADCS_NUM_AXES], const ADCS_CALC
 ADCS_CALC_TYPE ACS_IntensitiesRectifier(const ADCS_CALC_TYPE intensity1, const ADCS_CALC_TYPE intensity2, const uint32_t delta_t, const ADCS_CALC_TYPE amplitude);
 
 // Controller function
-void ACS_OnboardControl(const ADCS_CALC_TYPE state[ADCS_STATE_DIM], const ADCS_CALC_TYPE mag[ADCS_NUM_AXES], const float gain[ADCS_NUM_AXES][ADCS_STATE_DIM],
+void ACS_OnboardControl(const ADCS_CALC_TYPE stateVars[ADCS_STATE_DIM], const ADCS_CALC_TYPE mag[ADCS_NUM_AXES], const float gain[ADCS_NUM_AXES][ADCS_STATE_DIM],
                         const ADCS_CALC_TYPE coilChar[ADCS_NUM_AXES][ADCS_NUM_AXES], ADCS_CALC_TYPE intensity[ADCS_NUM_AXES], ADCS_CALC_TYPE controlLaw[ADCS_NUM_AXES]);
 
 #endif // ADCS_H_INCLUDED

--- a/software/FossaSat2/src/ADCS/ACS/onboardcontrol.cpp
+++ b/software/FossaSat2/src/ADCS/ACS/onboardcontrol.cpp
@@ -12,7 +12,7 @@
 #include "../ADCS/adcs.h"
 
 /****************** Main function *********************/
-void ACS_OnboardControl(const ADCS_CALC_TYPE state[ADCS_STATE_DIM], const ADCS_CALC_TYPE mag[ADCS_NUM_AXES], const float gain[ADCS_NUM_AXES][ADCS_STATE_DIM],
+void ACS_OnboardControl(const ADCS_CALC_TYPE stateVars[ADCS_STATE_DIM], const ADCS_CALC_TYPE mag[ADCS_NUM_AXES], const float gain[ADCS_NUM_AXES][ADCS_STATE_DIM],
                         const ADCS_CALC_TYPE coilChar[ADCS_NUM_AXES][ADCS_NUM_AXES], ADCS_CALC_TYPE intensity[ADCS_NUM_AXES], ADCS_CALC_TYPE controlLaw[ADCS_NUM_AXES]) {
   // Module of the magnetic field intensity
   const ADCS_CALC_TYPE B_module = ADCS_Add_Tolerance(ADCS_VectorNorm(mag), 0);
@@ -23,9 +23,9 @@ void ACS_OnboardControl(const ADCS_CALC_TYPE state[ADCS_STATE_DIM], const ADCS_C
   // Generation of the control law by means of a matrix product Lc = K*M
   for(uint8_t i = 0; i < ADCS_NUM_AXES; i++) {
     for(uint8_t j = 0; j < ADCS_STATE_DIM; j++) {
-      controlLawAux += (ADCS_CALC_TYPE)gain[i][j] * state[j];
-      controlLaw[i] = controlLawAux;
+      controlLawAux += (ADCS_CALC_TYPE)gain[i][j] * stateVars[j];
     }
+    controlLaw[i] = controlLawAux;
   }
   FOSSASAT_DEBUG_PRINT_ADCS_VECTOR(controlLaw, ADCS_NUM_AXES);
 

--- a/software/FossaSat2/src/ADCS/ADCS/adcs_main.cpp
+++ b/software/FossaSat2/src/ADCS/ADCS/adcs_main.cpp
@@ -306,6 +306,9 @@ void ADCS_ActiveControl_Update() {
       adcsState.kalmanMatrixP[i][j] = kalmanMatrixP[i][j];
     }
   }
+  adcsState.prevIntensity[0] = intensity[0];
+  adcsState.prevIntensity[1] = intensity[1];
+  adcsState.prevIntensity[2] = intensity[2];
 }
 
 uint8_t ADCS_Load_Ephemerides(const uint32_t row, ADCS_CALC_TYPE solarEph[ADCS_NUM_AXES], ADCS_CALC_TYPE magEph[ADCS_NUM_AXES]) {

--- a/software/FossaSat2/src/ADCS/ADS/ads_main.cpp
+++ b/software/FossaSat2/src/ADCS/ADS/ads_main.cpp
@@ -14,8 +14,9 @@
 
 /*****************  Auxiliary functions implementation *********************/
 bool ADS_Eclipse_Decision(const ADCS_CALC_TYPE luxData[ADCS_NUM_PANELS], const ADCS_CALC_TYPE threshold) {
-  ADCS_CALC_TYPE sum = 0;
-  for(uint8_t i = 0; i < ADCS_NUM_PANELS; i++) {
+  ADCS_CALC_TYPE sum = luxData[0];
+
+  for(uint8_t i = 2; i < ADCS_NUM_PANELS; i++) {
     sum += luxData[i];
   }
 

--- a/software/FossaSat2/src/ADCS/ADS/solar_determination.cpp
+++ b/software/FossaSat2/src/ADCS/ADS/solar_determination.cpp
@@ -11,7 +11,7 @@
 #include "../ADCS/adcs.h"
 
 /*************** Main function *****************/
-void ADS_Solar_Determination(const ADCS_CALC_TYPE luxData[ADCS_NUM_PANELS], ADCS_CALC_TYPE solarEph[ADCS_NUM_AXES], 
+void ADS_Solar_Determination(const ADCS_CALC_TYPE luxData[ADCS_NUM_PANELS], ADCS_CALC_TYPE solarEph[ADCS_NUM_AXES],
                              ADCS_CALC_TYPE redundantSolarEph[ADCS_NUM_AXES]) {
   // Constants definitions
   ADCS_CALC_TYPE panelUnitVector[ADCS_NUM_PANELS][ADCS_NUM_AXES] = ADCS_PANEL_UNIT_VECTOR; // Unitary vector pointing to the solar panels in inverse form
@@ -41,3 +41,15 @@ void ADS_Solar_Determination(const ADCS_CALC_TYPE luxData[ADCS_NUM_PANELS], ADCS
     }
   }
 }
+
+  // Normalize the solar ephemerides
+  ADCS_CALC_TYPE solarEphNorm = ADCS_VectorNorm(solarEph);
+  ADCS_CALC_TYPE redundantSolarEphNorm = ADCS_VectorNorm(redundantSolarEph);
+
+   for(uint8_t i = 0; i < ADCS_NUM_AXES; i++) {
+    solarEph[i] /= ADCS_Add_Tolerance(solarEphNorm, 0.0);
+    redundantSolarEph[i] /= ADCS_Add_Tolerance(redundantSolarEphNorm, 0.0);
+  }
+
+
+

--- a/software/FossaSat2/src/Configuration.h
+++ b/software/FossaSat2/src/Configuration.h
@@ -511,11 +511,11 @@
 #define ADCS_MIN_INERTIAL_MOMENT                        0.0003782 //
 #define ADCS_PULSE_AMPLITUDE                            0.1     //
 #define ADCS_CALCULATION_TOLERANCE                      0.001    //
-#define ADCS_ECLIPSE_THRESHOLD                          1.0     //
+#define ADCS_ECLIPSE_THRESHOLD                          0.28     // Eclipse condition reaching for a 20% output of the solar panels
 #define ADCS_ROTATION_WEIGHT_RATIO                      0.7     //  Weight ratio to average sensor, referred to the Euler integrator scheme (less accurate)
 #define ADCS_ROTATION_TRIGGER                           (M_PI/6.0) // Angular difference between sensor to trigger their averaging
-#define ADCS_DISTURBANCE_COVARIANCE                     0.01     // Covariance of the dynamical disturbances
-#define ADCS_NOISE_COVARIANCE                           0.01     // Covariance of the sensor noise
+#define ADCS_DISTURBANCE_COVARIANCE                     0.001     // Covariance of the dynamical disturbances
+#define ADCS_NOISE_COVARIANCE                           0.001     // Covariance of the sensor noise
 #define ADCS_COIL_CHARACTERISTICS                       { {15.833,       0,       0}, \
                                                           {     0, 893.655,       0}, \
                                                           {     0,       0, 108.551} }


### PR DESCRIPTION
Eclipse threshold is modified to account for a 20% output of the solar panels out of its maximum. Eclipse_decision function is modified to avoid using the solar sensor data.

Solar ephemerides in solar_determination are now normalized.

Active control updating between iterations is revised: intensities were not saved.

Variables names in onboardcontrol are changed to be consistent all along the system (stateVars)